### PR TITLE
[research-tools] Fix .mcp.json — use uvx mcp-server-fetch

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,9 @@
 {
   "mcpServers": {
     "fetch": {
-      "command": "npx",
-      "args": ["mcp-fetch-server"]
+      "command": "uvx",
+      "args": ["mcp-server-fetch"],
+      "description": "HTTP fetch — required for /web-research WebSearch and WebFetch calls"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fixes `.mcp.json` to use the correct `uvx mcp-server-fetch` format (was using non-standard `npx mcp-fetch-server`)
- Adds description field to clarify the MCP server's purpose

## Changes
- `.mcp.json`: command changed from `npx` + `mcp-fetch-server` to `uvx` + `mcp-server-fetch`

## Test plan
- [ ] \`claude mcp list\` shows fetch server after install
- [ ] \`/web-research\` can execute WebSearch calls

Closes #1