### PR TITLE
[research-tools] Add workflow guide, troubleshooting, ralph validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,60 @@ claude plugin install research-tools@musabkara-claude-marketplace
 | Command | Description |
 |---------|-------------|
 | `/web-research [focus]` | Market research -- competitors, user reviews, trends, UX patterns, monetization |
+| `/web-research --quick [focus]` | Rapid 5-minute scan — top competitors + key insights only |
 | `/project-analysis` | Deep 12-category project audit with parallel background agents |
+| `/project-analysis --all` | Non-interactive mode — runs all 12 categories automatically |
+| `/project-analysis --quick` | Quick scan — Security, Architecture, Performance only |
 | `/prd` | Generate a Product Requirements Document for a new feature |
 | `/ralph` | Convert PRD markdown to `prd.json` for autonomous execution |
 
+## Workflow
+
+The four commands are designed to work together in a sequential pipeline:
+
+```
+Step 1: /web-research          → market context, competitor gaps, user needs
+         ↓
+Step 2: /project-analysis --all → 12-category technical + product audit
+         ↓
+Step 3: /prd [feature]         → structured PRD from findings
+         ↓
+Step 4: /ralph                 → prd.json for autonomous implementation
+```
+
+### Example
+
+```bash
+# 1. Research the market
+/web-research competitors
+
+# 2. Audit your project
+/project-analysis --all
+
+# 3. Plan a feature based on findings
+/prd "User onboarding redesign"
+
+# 4. Convert for autonomous execution
+/ralph
+```
+
 ## MCP Dependency
 
-This plugin requires the **fetch** MCP server for web research capabilities. The `.mcp.json` file configures it automatically.
+This plugin requires the **fetch** MCP server for web research capabilities. The `.mcp.json` file configures it automatically when you install the plugin.
 
 ## Auto-Trigger
 
 The `skills/research-tools/SKILL.md` skill detects research, analysis, and PRD-related intent and routes to the correct command automatically.
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| `/web-research` fails with MCP error | Restart Claude Code to reload MCP servers; verify `uvx` is installed |
+| `uvx` not found | Install with `pip install uv` or `brew install uv` |
+| `/prd` fails to save | Ensure you have write permission in the project directory |
+| `tasks/` directory missing | Not needed — `/prd` creates it automatically |
+| `/project-analysis --all` hangs | Try `/project-analysis --quick` for a faster scan |
 
 ## License
 

--- a/commands/ralph.md
+++ b/commands/ralph.md
@@ -66,3 +66,37 @@ Default: 10 iterations. Each iteration spawns a fresh Claude Code instance.
 If `prd.json` already exists with a different `branchName`, archive first:
 - Copy current `prd.json` + `progress.txt` to `archive/YYYY-MM-DD-feature/`
 - `ralph.sh` handles this automatically
+
+## Output Validation
+
+After generating `prd.json`, validate the output against this schema before finishing:
+
+### Required Fields Check
+```
+project        → string, non-empty
+branchName     → string, matches pattern "ralph/[a-z0-9-]+"
+description    → string, non-empty
+userStories    → array, length >= 1
+```
+
+### Per-Story Check
+```
+id             → string, matches "US-NNN"
+title          → string, non-empty, max 80 chars
+description    → string, contains "As a", "I want", "so that"
+acceptanceCriteria → array, length >= 2, includes "Typecheck passes"
+priority       → integer >= 1
+passes         → boolean, must be false
+notes          → string (can be empty)
+```
+
+### Self-Correction
+If any field fails validation, fix it before saving the file. Do not output an invalid `prd.json`. Show a brief validation summary at the end:
+
+```
+prd.json validated:
+  ✓ 7 user stories
+  ✓ All required fields present
+  ✓ All acceptance criteria include "Typecheck passes"
+  ✓ branchName: ralph/user-onboarding-redesign
+```


### PR DESCRIPTION
## Summary
- README: adds Workflow section with 4-step pipeline (web-research → analysis → prd → ralph)
- README: adds Troubleshooting table for common issues (MCP, uvx, directory errors)
- README: updates Commands table with new --all, --quick flags
- ralph.md: adds Output Validation section with schema checks and self-correction instructions

Closes #6, #7